### PR TITLE
Make half budget optional

### DIFF
--- a/aws_budget.half.tf
+++ b/aws_budget.half.tf
@@ -1,4 +1,5 @@
 resource "aws_budgets_budget" "half" {
+  count             = var.half_budget_enabled ? 1 : 0
   name              = "half-${var.budget["name"]}"
   budget_type       = var.budget["budget_type"]
   limit_amount      = var.limit / 2

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,9 @@ variable "cost_filters" {
   type        = map(any)
   default     = null
 }
+
+variable "half_budget_enabled" {
+  description = "Wether to enable or disable the half budget alert"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This makes the "half-budget" alert optional, as mentioned in #2 