### PR TITLE
Add variable type for notification

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,13 @@ variable "budget" {
 
 variable "notification" {
   description = "Budget notification properties"
+  type        = object({
+    comparison_operator        = string
+    threshold                  = number
+    threshold_type             = string
+    notification_type          = string
+    subscriber_email_addresses = set(string)
+  })
 }
 
 variable "cost_filters" {


### PR DESCRIPTION
This change adds compatibility with Terraform 1.0.x. Without it TF raises an error:
```
Error: Invalid index

  on aws_budget.full.tf line 12, in resource "aws_budgets_budget" "full":
  12:     comparison_operator        = var.notification["comparison_operator"]
    |----------------
    | var.notification is "{\"comparison_operator\":\"GREATER_THAN\",\"notification_type\":\"ACTUAL\",\"subscriber_email_addresses\":[\"nonono@example.tld\"],\"threshold\":\"80\",\"threshold_type\":\"PERCENTAGE\"}"

This value does not have any indices.

```