### PR TITLE
Make notifications configurable, allow specifying a set of SNS Topic arns

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ notification={
     threshold_type             = "PERCENTAGE"
     notification_type          = "FORECASTED"
     subscriber_email_addresses = ["test@example.com"]
+    subscriber_sns_topic_arns  = [""]
   }
 ```
 
@@ -85,7 +86,7 @@ No modules.
 | <a name="input_cost_filters"></a> [cost_filters](#input_cost_filters)                      | The Budget filters to use                          | `map(any)`                                                                                                                                                                                 | `null`                                                                                                                             |    no    |
 | <a name="input_half_budget_enabled"></a> [half_budget_enabled](#input_half_budget_enabled) | Whether to enable or disable the half budget alert | `bool`                                                                                                                                                                                     | `true`                                                                                                                             |    no    |
 | <a name="input_limit"></a> [limit](#input_limit)                                           | Budget alarm limit                                 | `number`                                                                                                                                                                                   | n/a                                                                                                                                |   yes    |
-| <a name="input_notification"></a> [notification](#input_notification)                      | Budget notification properties                     | <pre>object({<br> comparison_operator = string<br> threshold = number<br> threshold_type = string<br> notification_type = string<br> subscriber_email_addresses = set(string)<br> })</pre> | n/a                                                                                                                                |   yes    |
+| <a name="input_notification"></a> [notification](#input_notification)                      | Budget notification properties                     | <pre>object({<br> comparison_operator = string<br> threshold = number<br> threshold_type = string<br> notification_type = string<br> subscriber_email_addresses = set(any)<br> subscriber_sns_topic_arns = set(any) })</pre> | n/a                                                                                                                                |   yes    |
 | <a name="input_time_period_start"></a> [time_period_start](#input_time_period_start)       | Time to start                                      | `string`                                                                                                                                                                                   | n/a                                                                                                                                |   yes    |
 
 ## Outputs

--- a/aws_budget.full.tf
+++ b/aws_budget.full.tf
@@ -14,5 +14,6 @@ resource "aws_budgets_budget" "full" {
     threshold_type             = var.notification["threshold_type"]
     notification_type          = var.notification["notification_type"]
     subscriber_email_addresses = var.notification["subscriber_email_addresses"]
+    subscriber_sns_topic_arns  = var.notification["subscriber_sns_topic_arns"]
   }
 }

--- a/example/examplea/examplea.auto.tfvars
+++ b/example/examplea/examplea.auto.tfvars
@@ -13,6 +13,7 @@ notification = {
   threshold_type             = "PERCENTAGE"
   notification_type          = "FORECASTED"
   subscriber_email_addresses = ["james.woolfended@gmail.com"]
+  subscriber_sns_topic_arns  = []
 }
 
 cost_filters = {}

--- a/example/examplea/variables.tf
+++ b/example/examplea/variables.tf
@@ -25,7 +25,8 @@ variable "notification" {
     threshold                  = number
     threshold_type             = string
     notification_type          = string
-    subscriber_email_addresses = set(string)
+    subscriber_email_addresses = set(any)
+    subscriber_sns_topic_arns  = set(any)
   })
 }
 variable "cost_filters" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "notification" {
     threshold_type             = string
     notification_type          = string
     subscriber_email_addresses = set(any)
-    subscriber_sns_topic_arns = set(any)
+    subscriber_sns_topic_arns  = set(any)
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,8 @@ variable "notification" {
     threshold                  = number
     threshold_type             = string
     notification_type          = string
-    subscriber_email_addresses = set(string)
+    subscriber_email_addresses = set(any)
+    subscriber_sns_topic_arns = set(any)
   })
 }
 


### PR DESCRIPTION
* This allows specifying a set of SNS Topic ARNs instead of only configuring email-notifications