### PR TITLE
feat: Add the ability to declare multiple cost filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_budget"></a> [budget](#input\_budget) | Basic Budget Properties | `map(any)` | <pre>{<br>  "budget_type": "COST",<br>  "limit_unit": "USD",<br>  "name": "budget-ec2-monthly",<br>  "time_unit": "MONTHLY"<br>}</pre> | no |
-| <a name="input_cost_filters"></a> [cost\_filters](#input\_cost\_filters) | The Budget filters to use | <pre>object({<br>    name   = string<br>    values = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_cost_filters"></a> [cost\_filters](#input\_cost\_filters) | The Budget filters to use | <pre>list(object({<br>    name   = string<br>    values = set(string))<br>  })</pre> | `[]` | no |
 | <a name="input_half_budget_enabled"></a> [half\_budget\_enabled](#input\_half\_budget\_enabled) | Whether to enable or disable the half budget alert | `bool` | `true` | no |
 | <a name="input_limit"></a> [limit](#input\_limit) | Budget alarm limit | `number` | n/a | yes |
 | <a name="input_notification"></a> [notification](#input\_notification) | Budget notification properties | <pre>object({<br>    comparison_operator        = string<br>    threshold                  = number<br>    threshold_type             = string<br>    notification_type          = string<br>    subscriber_email_addresses = set(any)<br>    subscriber_sns_topic_arns  = set(any)<br>  })</pre> | n/a | yes |

--- a/aws_budgets_budget.budget.tf
+++ b/aws_budgets_budget.budget.tf
@@ -7,9 +7,12 @@ resource "aws_budgets_budget" "budget" {
   time_unit         = var.budget["time_unit"]
   time_period_start = var.time_period_start
 
-  cost_filter {
-    name   = var.cost_filters["name"]
-    values = var.cost_filters["values"]
+  dynamic "cost_filter" {
+    for_each = toset(var.cost_filters)
+    content {
+      name   = cost_filter.value.name
+      values = cost_filter.value.values
+    }
   }
 
   notification {

--- a/example/examplea/examplea.auto.tfvars
+++ b/example/examplea/examplea.auto.tfvars
@@ -16,4 +16,4 @@ notification = {
   subscriber_sns_topic_arns  = []
 }
 
-//cost_filters = {}
+//cost_filters = []

--- a/variables.tf
+++ b/variables.tf
@@ -33,11 +33,11 @@ variable "notification" {
 
 variable "cost_filters" {
   description = "The Budget filters to use"
-  type = object({
+  type = list(object({
     name   = string
     values = set(string)
-  })
-  default = null
+  }))
+  default = []
 }
 
 variable "half_budget_enabled" {


### PR DESCRIPTION
* Use a dynamic block on 'cost_filters' to iterate over the list of objects. This way we can declare multiple filters.

BREAKING CHANGE: cost_filters variable is now a list of objects, not single object.